### PR TITLE
Promote Artemis and Roary

### DIFF
--- a/config/Artemis.yml
+++ b/config/Artemis.yml
@@ -1,1 +1,2 @@
-highlight
+---
+score_multiplier: 20

--- a/config/Roary.yml
+++ b/config/Roary.yml
@@ -1,1 +1,2 @@
-highlight
+---
+score_multiplier: 15


### PR DESCRIPTION
As discussed with @martinghunt this puts Artemis in the top spot and adds Roary to the list of featured repos.  The changes should go live next time the cron job runs.
